### PR TITLE
Remove develop branch from GitHub integrations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Mark this Pull Request as Ready for Review when you're happy with all the change
 <!-- Maintainers: please check the following before you merge-->
 - [ ] Built site locally.
 - [ ] Changes are as discussed in issue.
-- [ ] The PR is to the Our Handbook `develop` branch
+- [ ] The PR is to the Our Handbook `main` branch
 - [ ] New pages are linked in the TOC/navigation?
 - [ ] Have we added the contributor to our all-contributors?
 - [ ] One sentence per line

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -6,12 +6,12 @@ name: build-site
 on:
   # Triggers the workflow on push or pull request events but only for the main branch for the book content directory.
   push:
-    branches: [ develop ]
+    branches: [ main ]
     paths:
       book/**
 
   pull_request:
-    branches: [ main, develop]
+    branches: [ main ]
     paths:
       book/**
 


### PR DESCRIPTION
## Description
I've noticed a couple of the GitHub integrations still refer to the `develop` branch. This commit changes them to `main`.

## Question
Is this what we intend for `.github/workflows/build-site.yml` and `.github/workflows/deploy-site.yml`?

At the moment it:
* _builds_ for pushes to `develop`, or pull requests to `main` or `develop` (to check for errors)
* _deploys_ for pushes to `main` (to actually update GH Pages)

This PR will change that to:
* _builds_ for pushes to `main`, or pull requests to `main` (to check for errors)
* _deploys_ for pushes to `main` (to actually update GH Pages)

__However,__ I'm wondering if that should instead just be:
* _builds_ for pull requests to `main` (to check for errors)
* _deploys_ for pushes to `main` (to actually update GH Pages)